### PR TITLE
ch05-02: machine-mode return is mret, not reti

### DIFF
--- a/src/ch05-02-loader.md
+++ b/src/ch05-02-loader.md
@@ -197,7 +197,7 @@ Execution continues in `start_kernel`, which is currently located in `asm.S` (bu
 In order to allow interrupts and exceptions to be handled by the kernel, which runs in Supervisor mode, the loader sets `mideleg` to `0xffffffff` in order to delegate all interrupts to Supervisor mode, and it sets `medeleg` to `0xffffffff` in order to delegate all CPU exceptions to the kernel.
 
 The loader then does the handover by setting `mepc` (the exception return program counter - contains the virtual address of the instruction that
-nominally triggered the exception) to the `entrypoint` of the kernel, and issuing a `reti` (Return from Interrupt) opcode.
+nominally triggered the exception) to the `entrypoint` of the kernel, and issuing an `mret` (Machine-mode Return) instruction.
 
 Thus one can effectively think of this entire "boot process" as just one big machine mode exception that started at the reset vector, and now, we can return from this exception and resume in Supervisor (kernel) code.
 


### PR DESCRIPTION
Refs #11 (Bucket 3, item 3a). Opening per bunnie's request in [#11 (comment)](https://github.com/betrusted-io/xous-book/issues/11#issuecomment-4431118549) to send substantive description fixes as individual PRs.

### What's wrong

[`ch05-02-loader.md` L200](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch05-02-loader.md#L200)
describes the loader's handover to the kernel as:

> ...and issuing a `reti` (Return from Interrupt) opcode.

`reti` is a Z80 mnemonic and isn't part of RISC-V at all. The RV32 ISA's machine-mode trap-return instruction is `mret`. The loader's own assembly confirms this — `loader/src/asm.rs` finishes [`start_kernel`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/loader/src/asm.rs#L249-L308) with [`mret`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/loader/src/asm.rs#L296) right after writing `mepc`, exactly as the paragraph describes — only the mnemonic in the prose is wrong.

### Fix

```diff
-nominally triggered the exception) to the `entrypoint` of the kernel, and issuing a `reti` (Return from Interrupt) opcode.
+nominally triggered the exception) to the `entrypoint` of the kernel, and issuing an `mret` (Machine-mode Return) instruction.
```

One-character abbreviation aside, the expansion in parentheses also gets swapped from "Return from Interrupt" to "Machine-mode Return" (mret is in the trap-return family but it's not specifically an interrupt return — it
returns to whatever `mepc` points at, which here is the kernel's entrypoint, not a faulted instruction). I also changed `opcode` to `instruction` for consistency with how RISC-V instructions are usually described in the rest of the chapter.

### Adjacent issue (will not fix in this PR)

[L195](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch05-02-loader.md#L195) still says `start_kernel` "is currently located in `asm.S` (but is slated to migrate into a `.rs` file now that assembly is part of stable Rust)" — but it has already migrated; `start_kernel` is now in
[`loader/src/asm.rs`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/loader/src/asm.rs#L249-L308).

Happy to drop that parenthetical in a follow-up PR (or here, if you'd rather keep this one bundled — but I figured a single-line factual fix is easier to review without scope creep).

### Verification (local)

One-file change, +1/-1.

| Check | Result |
|---|---|
| `mdbook build` | clean, no warnings (same as `main`) |
| `mdbook test` | clean (same as `main`) |
| `bash ci/spellcheck.sh list` | 13,077 lines on this branch vs. 13,076 on `main`; **zero new uniquely-flagged words** (`reti` was flagged on `main`; `mret` is flagged on this branch — one-for-one swap. Confirmed by `comm -13` on the unique-word sets.) |
| `bash ci/validate.sh` | same 3 pre-existing `link2print` panics as `main`, no new ones |
