### PR TITLE
ch05-02: fix detached-signature padding offset

### DIFF
--- a/src/ch05-02-loader.md
+++ b/src/ch05-02-loader.md
@@ -29,7 +29,7 @@ Signatures for both the loader and the kernel share a common structure. They con
 | 0      | 4               | Version   | Version number of the signature record. Currently `1`                                                               |
 | 4      | 4               | Length    | Length of the signed region (should be exactly +4 over the Length field in the signed region)                       |
 | 8      | 64              | Signature | 64-byte Ed25519 signature of the signed region                                                                      |
-| 12     | pad             | Padding   | 0-pad up to 4096 bytes                                                                                              |
+| 72     | pad             | Padding   | 0-pad up to 4096 bytes                                                                                              |
 
 The signed region has the following format:
 


### PR DESCRIPTION
Refs #11 (Bucket 3, item 3b).

### What's wrong

[`ch05-02-loader.md` L27-32](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch05-02-loader.md#L27-L32) documents the detached-signature header as:

| Offset | Size | Name      |
| ------ | ---- | --------- |
| 0      | 4    | Version   |
| 4      | 4    | Length    |
| 8      | 64   | Signature |
| **12** | pad  | Padding   |

Signature starts at offset 8 with size 64, so padding starts at 8 + 64 = **72**, not 12. The 64-byte signature would otherwise overlap the "padding" row by 60 bytes.

The on-disk struct in the loader confirms this layout: [`SignatureInFlash` at `loader/src/secboot.rs` L22-L26](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/loader/src/secboot.rs#L22-L26) is `{ version: u32, signed_len: u32, signature: [u8; 64] }`, totaling 72 bytes before whatever follows in flash. The loader uses this struct verbatim as the on-flash layout via a direct pointer cast at [`loader/src/secboot.rs` L262-L266](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/loader/src/secboot.rs#L262-L266) — so the 72 bytes really is the on-flash footprint, not an in-RAM-only representation.

### Fix

```diff
-| 12     | pad             | Padding   | 0-pad up to 4096 bytes                                                                                              |
+| 72     | pad             | Padding   | 0-pad up to 4096 bytes                                                                                              |
```

### Verification (local)

One-file change, +1/-1.

| Check | Result |
|---|---|
| `mdbook build` | clean, no warnings (same as `main`) |
| `mdbook test` | clean (same as `main`) |
| `bash ci/spellcheck.sh list` | no change vs `main` (numeric edit only) |
| `bash ci/validate.sh` | same 3 pre-existing `link2print` panics as `main`, no new ones |
