### PR TITLE
ch05-01: correct IniE/IniF and MREx section index formulas

### DIFF
--- a/src/ch05-01-arguments.md
+++ b/src/ch05-01-arguments.md
@@ -71,9 +71,9 @@ Following this is a list of *section definitions*. Section definitions must be s
 
 | Offset | Size | Name            | Description                                  |
 | ------ | ---- | --------------- | -------------------------------------------- |
-| n*3+8  | 8    | SECTIONn_OFFSET | Virtual memory address of memory section _n_ |
-| n*3+12 | 3    | SECTIONn_SIZE   | Size of memory section _n_                   |
-| n*3+15 | 1    | SECTIONn_FLAGS  | Flags describing memory section _n_          |
+| 8n+8   | 4    | SECTIONn_OFFSET | Virtual memory address of memory section _n_ |
+| 8n+12  | 3    | SECTIONn_SIZE   | Size of memory section _n_                   |
+| 8n+15  | 1    | SECTIONn_FLAGS  | Flags describing memory section _n_          |
 
 The fields `size`, `flags`, and `offset` together occupy 64 bits (8 bytes). The
 `OFFSET` is a full 32-bit address.  The `SIZE` field is in units of
@@ -146,8 +146,8 @@ Each additional memory entry is 3 words of 4-bytes each:
 
 | Offset   | Size | Name   | Description                                                                        |
 | -------- | ---- | ------ | ---------------------------------------------------------------------------------- |
-| n*3 + 4  | 4    | Start  | The start offset of this additional region                                         |
-| n*3 + 8  | 4    | Length | The length of this additional region                                               |
-| n*3 + 12 | 4    | Name   | A 4-character name of this region that should be printable -- useful for debugging |
+| 12n + 4  | 4    | Start  | The start offset of this additional region                                         |
+| 12n + 8  | 4    | Length | The length of this additional region                                               |
+| 12n + 12 | 4    | Name   | A 4-character name of this region that should be printable -- useful for debugging |
 
 Additional memory regions should be non-overlapping. Creating overlapping memory regions will simply waste memory, as the loader will allocate multiple regions to track the memory yet will only allow it to be shared once.


### PR DESCRIPTION
Refs #11 (Bucket 3, item 3c). Both tables in ch05-01 had a 3-byte stride that produces overlapping entries; they should be 8 and 12 respectively.

### What's wrong

**IniE / IniF section table** at [`ch05-01-arguments.md` L72-76](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch05-01-arguments.md#L72-L76):

| Offset (in book) | Size (in book) | Name            |
| ---------------- | -------------- | --------------- |
| **n\*3+8**       | **8**          | SECTIONn_OFFSET |
| **n\*3+12**      | 3              | SECTIONn_SIZE   |
| **n\*3+15**      | 1              | SECTIONn_FLAGS  |

For `n=1` this would put SECTIONn_OFFSET at byte 11 — inside section 0's own SIZE/FLAGS bytes. The stride must equal the entry size, which is 8 bytes — see the chapter's own prose at [`ch05-01-arguments.md` L78-L79](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch05-01-arguments.md#L78-L79): *"`size`, `flags`, and `offset` together occupy 64 bits (8 bytes). The `OFFSET` is a full 32-bit address."* The Size column for SECTIONn_OFFSET also says `8`, but per the same prose it's a 32-bit address — i.e. 4 bytes; the `8` was the entry total accidentally landing in the field's row.

The code agrees in two places:

- the [`MiniElfSection`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/loader/src/minielf.rs#L26-L34) struct is `#[repr(C)] { virt: u32, size_and_flags: u32 }` — 8 bytes total, with the OFFSET (`virt`) being a single `u32`;
- the loader counts sections with [`(tag.size as usize - 8) / mem::size_of::<MiniElfSection>()`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/loader/src/minielf.rs#L68-L73), which is the cross-check that the section block starts at byte 8 of the tag (after `LOAD_OFFSET` + `ENTRYPOINT`) and that each section entry is exactly `size_of::<MiniElfSection>()` = 8 bytes.

**MREx section table** at [`ch05-01-arguments.md` L147-151](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch05-01-arguments.md#L147-L151):

| Offset (in book) | Size | Name   |
| ---------------- | ---- | ------ |
| **n\*3 + 4**     | 4    | Start  |
| **n\*3 + 8**     | 4    | Length |
| **n\*3 + 12**    | 4    | Name   |

The chapter's own prose at [`ch05-01-arguments.md` L145](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch05-01-arguments.md#L145) already establishes the stride: *"Each additional memory entry is 3 words of 4-bytes each"* → 12 bytes per entry, not 3. With `n*3` the second entry's `Start` would be at byte 7 — collides with the first entry's `Length`.

### Fix

```diff
 | Offset | Size | Name            | Description                                  |
 | ------ | ---- | --------------- | -------------------------------------------- |
-| n*3+8  | 8    | SECTIONn_OFFSET | Virtual memory address of memory section _n_ |
-| n*3+12 | 3    | SECTIONn_SIZE   | Size of memory section _n_                   |
-| n*3+15 | 1    | SECTIONn_FLAGS  | Flags describing memory section _n_          |
+| 8n+8   | 4    | SECTIONn_OFFSET | Virtual memory address of memory section _n_ |
+| 8n+12  | 3    | SECTIONn_SIZE   | Size of memory section _n_                   |
+| 8n+15  | 1    | SECTIONn_FLAGS  | Flags describing memory section _n_          |
```

```diff
 | Offset   | Size | Name   | Description                                                                        |
 | -------- | ---- | ------ | ---------------------------------------------------------------------------------- |
-| n*3 + 4  | 4    | Start  | The start offset of this additional region                                         |
-| n*3 + 8  | 4    | Length | The length of this additional region                                               |
-| n*3 + 12 | 4    | Name   | A 4-character name of this region that should be printable -- useful for debugging |
+| 12n + 4  | 4    | Start  | The start offset of this additional region                                         |
+| 12n + 8  | 4    | Length | The length of this additional region                                               |
+| 12n + 12 | 4    | Name   | A 4-character name of this region that should be printable -- useful for debugging |
```

The n=0 values stay identical in both tables (still 8/12/15 for IniE/IniF, and 4/8/12 for MREx) — only the stride and the OFFSET-field size change.

### Verification (local)

One-file change, +6/-6.

| Check | Result |
|---|---|
| `mdbook build` | clean, no warnings (same as `main`) |
| `mdbook test` | clean (same as `main`) |
| `bash ci/spellcheck.sh list` | no change vs `main` (numeric edit only) |
| `bash ci/validate.sh` | same 3 pre-existing `link2print` panics as `main`, no new ones |
