### PR TITLE
ch03-02: hosted mode sends nine 32-bit values, not eight

### DIFF
--- a/src/ch03-02-hosted-mode.md
+++ b/src/ch03-02-hosted-mode.md
@@ -87,7 +87,7 @@ In Hosted mode, syscalls are sent via a network connection. Because pointers are
 
 Messages function normally in Hosted mode, however they are more expensive than on real hardware. Because messages get sent via the network, the entire contents of a Memory message must be sent across the wire.
 
-Eight 32-bit values are sent, and these may be followed by any data in case there is a Memory message.
+Nine 32-bit values are sent, and these may be followed by any data in case there is a Memory message.
 
 | Offset (Bytes) | Usage (Calling)                           |
 | -------------- | ----------------------------------------- |


### PR DESCRIPTION
Refs #11 (Bucket 3, item 3d). The prose is off by one against the table it introduces.

### What's wrong

[`ch03-02-hosted-mode.md` L90](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch03-02-hosted-mode.md#L90) says:

> Eight 32-bit values are sent, and these may be followed by any data in
> case there is a Memory message.

The table immediately after at [`ch03-02-hosted-mode.md` L92-L102](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch03-02-hosted-mode.md#L92-L102) actually lists nine fields at offsets 0/4/8/12/16/20/24/28/32 — TID, Syscall, then Args 1-7.

Both the wire-format reader and the send path confirm it's nine. Reader at [`xous-rs/src/arch/hosted/mod.rs` L191-L205](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/hosted/mod.rs#L191-L205):

```rust
let mut pkt = [0usize; 8];
let mut raw_bytes = [0u8; size_of::<usize>() * 9];
if let Err(e) = stream.read_exact(&mut raw_bytes) { … }
…
let msg_thread_id = TID::from_le_bytes(raw_bytes_chunks.next().unwrap().try_into().unwrap());
for (pkt_word, word) in pkt.iter_mut().zip(raw_bytes_chunks) {
    *pkt_word = usize::from_le_bytes(word.try_into().unwrap());
}
```

(1 TID + 8 `pkt` words = 9 total `usize` reads per packet.)

Send path at [`xous-rs/src/arch/hosted/mod.rs` L340-L348](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/hosted/mod.rs#L340-L348) is the mirror: it writes the TID first, then iterates `args` — preserving the same 1 + N layout the reader expects.

### Fix

```diff
-Eight 32-bit values are sent, and these may be followed by any data in case there is a Memory message.
+Nine 32-bit values are sent, and these may be followed by any data in case there is a Memory message.
```

### Verification (local)

One-file change, +1/-1.

| Check | Result |
|---|---|
| `mdbook build` | clean, no warnings (same as `main`) |
| `mdbook test` | clean (same as `main`) |
| `bash ci/spellcheck.sh list` | no change vs `main` |
| `bash ci/validate.sh` | same 3 pre-existing `link2print` panics as `main`, no new ones |
