### PR TITLE
ch09-01, ch09-03: PDDB name-length limits are LEN-1, not LEN

### DIFF
--- a/src/ch09-01-basis.md
+++ b/src/ch09-01-basis.md
@@ -85,8 +85,9 @@ of keys in the dictionary. Following the header is a list of key descriptors. Si
 the key descriptors are stored at a stride of 127 (or 32 per `VPAGE`); they can be deleted by being marked
 as invalid, and a linear scan is used to identify all the entries. A KeyDescriptor contains the name
 of the key, flags, its age, and pointers to the key data in virtual memory space + its length.
-This leads to a name length restriction of roughly 115 characters for keys and dictionaries, which is
-about half of what most filesystems allow, but accommodates roughly 99.99% of the use cases.
+This leads to a name length restriction of up to 110 bytes for dictionary names and 94 bytes for key
+names (see [`Pddb::get`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/pddb/src/lib.rs#L542-L555)),
+which is about half of what most filesystems allow but accommodates roughly 99.99% of the use cases.
 
 Thus adding a new dictionary always consumes at least one 4k page, but you can have up to 15 keys
 in that dictionary with no extra bookkeeping cost, once the first dictionary is added.

--- a/src/ch09-03-api-native.md
+++ b/src/ch09-03-api-native.md
@@ -27,9 +27,9 @@ pub fn get(
 ) -> Result<PddbKey>
 ```
 
-`dict_name` and `key_name` are the names of the dictionary and key. They can be any valid UTF-8 string but you should avoid the `:` character as that is the path separator. Dictionary names can be up to 111 bytes long, and key names up to 95 bytes long.
+`dict_name` and `key_name` are the names of the dictionary and key. They can be any valid UTF-8 string but you should avoid the `:` character as that is the path separator. Dictionary names can be up to 110 bytes long, and key names up to 94 bytes long. (The `DICT_NAME_LEN` and `KEY_NAME_LEN` constants in `services/pddb/src/api.rs` give the slot size — 111 and 95 — but `Pddb::get` rejects names equal to or longer than the slot, so the accepted maximum is one less.)
 
-`basis_name` is an optional Basis name, that can be any valid UTF-8 string that avoids `:`. Basis names can be up to 64 bytes long. If `basis_name` is `None`, then the Basis to use will be computed as follows:
+`basis_name` is an optional Basis name, that can be any valid UTF-8 string that avoids `:`. Basis names can be up to 63 bytes long. If `basis_name` is `None`, then the Basis to use will be computed as follows:
 
 - If the key exists in any Basis, the most recently open Basis is accessed for that key.
 - If the key does not exist, then either it returns an error (depending on the flags), or it creates the key in the most recently opened Basis.


### PR DESCRIPTION
Refs #11 (Bucket 3, item 3e). Two book sites quote the *slot* size from `api.rs`, but the actual user-visible limit is one less because `Pddb::get` rejects strings whose length equals the slot.

### What's wrong

[`Pddb::get` L542-L555](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/pddb/src/lib.rs#L542-L555):

```rust
if key_name.len() > (KEY_NAME_LEN - 1) { return Err(…); }
if dict_name.len() > (DICT_NAME_LEN - 1) { return Err(…); }
let bname = if let Some(bname) = basis_name {
    if bname.len() > BASIS_NAME_LEN - 1 { return Err(…); }
    …
};
```

With [constants from `services/pddb/src/api.rs` L27-L31](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/pddb/src/api.rs#L27-L31) (`BASIS_NAME_LEN = 64`, `DICT_NAME_LEN = 111`, `KEY_NAME_LEN = 95`), the accepted maxima are basis 63, dict 110, key 94.

Two book sites quote the wrong numbers:

1. [`ch09-01-basis.md`
L88](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch09-01-basis.md#L88):
   > This leads to a name length restriction of roughly 115 characters
   > for keys and dictionaries…

The "roughly 115" is wrong, and dictionary and key names actually differ by 16 bytes — they are not the same limit.

2. [`ch09-03-api-native.md`
L30-L32](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch09-03-api-native.md#L30-L32):
   > Dictionary names can be up to 111 bytes long, and key names up to 95
   > bytes long.
   > […]
   > Basis names can be up to 64 bytes long.

All three are the *slot* size, one byte too large.

### Fix

```diff
-This leads to a name length restriction of roughly 115 characters for keys and dictionaries, which is
-about half of what most filesystems allow, but accommodates roughly 99.99% of the use cases.
+This leads to a name length restriction of up to 110 bytes for dictionary names and 94 bytes for key
+names (see [`Pddb::get`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/pddb/src/lib.rs#L542-L555)),
+which is about half of what most filesystems allow but accommodates roughly 99.99% of the use cases.
```

```diff
-`dict_name` and `key_name` are the names of the dictionary and key. They can be any valid UTF-8 string but you should avoid the `:` character as that is the path separator. Dictionary names can be up to 111 bytes long, and key names up to 95 bytes long.
+`dict_name` and `key_name` are the names of the dictionary and key. They can be any valid UTF-8 string but you should avoid the `:` character as that is the path separator. Dictionary names can be up to 110 bytes long, and key names up to 94 bytes long. (The `DICT_NAME_LEN` and `KEY_NAME_LEN` constants in `services/pddb/src/api.rs` give the slot size — 111 and 95 — but `Pddb::get` rejects names equal to or longer than the slot, so the accepted maximum is one less.)

-`basis_name` is an optional Basis name, that can be any valid UTF-8 string that avoids `:`. Basis names can be up to 64 bytes long. If `basis_name` is `None`, then the Basis to use will be computed as follows:
+`basis_name` is an optional Basis name, that can be any valid UTF-8 string that avoids `:`. Basis names can be up to 63 bytes long. If `basis_name` is `None`, then the Basis to use will be computed as follows:
```

The parenthetical in ch09-03 is there because the constants will *look* like the limit if a reader greps for them in `api.rs` — flagging the off-by-one so the next reader doesn't get the same impression.

### Verification (local)

Two files, +5/-4.

| Check | Result |
|---|---|
| `mdbook build` | clean, no warnings (same as `main`) |
| `mdbook test` | clean (same as `main`) |
| `bash ci/spellcheck.sh list` | zero new uniquely-flagged words on either chapter (`comm -13` on per-chapter sets returns empty). Line count rises because the new URL path contains `betrusted` / `pddb` — both already-flagged words elsewhere in the same chapters. |
| `bash ci/validate.sh` | same 3 pre-existing `link2print` panics as `main`, no new ones |
