### PR TITLE
ch10: update SwapAbi listing for new userspace variants

### DIFF
--- a/src/ch10-00-swap-overview.md
+++ b/src/ch10-00-swap-overview.md
@@ -219,16 +219,24 @@ pub enum SwapAbi {
     Invalid = 0,
     ClearMemoryNow = 1,
     GetFreePages = 2,
-    RetrievePage = 3,
-    HardOom = 4,
+    // RetrievePage = 3, // meant to be initiated within the kernel to itself
+    // HardOom = 4, // meant to be initiated within the kernel to itself
     StealPage = 5,
     ReleaseMemory = 6,
+    WritePage = 7,
+    BlockErase = 8,
+    DebugProcesses = 9,
+    DebugServers = 10,
+    DebugFree = 11,
+    DebugInterrupts = 12,
 }
 ```
 
 `ClearMemoryNow` is the call used when the system has run out of physical memory. Only the swapper is allowed to invoke this call; other processes may proxy a request for memory through the swapper's userspace server. This call stops all interrupts, and immediately enters the userspace handler to nominate pages to evict in hopes of recovery.
 
 `GetFreePages` returns the number of physical pages currently unallocated.
+
+`RetrievePage` and `HardOom` are kernel-internal — they live in the kernel's own `SwapAbi` definition but are commented out in the userspace enum because no userspace caller is supposed to issue them.
 
 `RetrievePage` is used to retrieve a page that has been previously swapped out into physical memory. It must be called with the target PID and virtual address of the page to be retrieved, along with a physical address of where to put the retrieved page.
 
@@ -237,6 +245,12 @@ pub enum SwapAbi {
 `StealPage` instructs the kernel to mark a specified page in the victim process' memory space as swapped, and return its contents for storage in swap. The userspace swapper is responsible for swap strategy, and this is one half of the call that it uses to execute the strategy.
 
 `ReleaseMemory` instructs the kernel to mark a specified physical page in the swapper's memory space as no longer used, returning it to the free memory pool. This is called after a successful `StealPage` call followed up by archival of the swapped page to encrypted swap.
+
+`WritePage` is the swapper-only call that pushes a page's contents into encrypted swap on FLASH. The kernel takes the page contents at the swapper-provided virtual address and writes them to the given flash offset.
+
+`BlockErase` is the swapper-only call that erases a FLASH block in preparation for new swap writes. As with `WritePage`, only the swapper is allowed to invoke it.
+
+`DebugProcesses`, `DebugServers`, `DebugFree`, and `DebugInterrupts` are diagnostic calls that ask the kernel to print or return tables of currently-allocated processes, registered servers, free-memory totals, and claimed interrupts, respectively. They exist primarily so a console user can introspect the swapper-affected kernel state without rebuilding with a debug print enabled.
 
 Most of the interesting code for the swapper is split between the kernel stub (inside kernel/src/swap.rs) and the userspace service (services/xous-swapper). The userspace service itself is split into the blocking handler and the regular preemptable handler, with most of the action happening in the blocking handler. The blocking handler is named such because it happens in an interrupt-like context: no pre-emption of any type is allowed.
 


### PR DESCRIPTION
Refs #11 (Bucket 3, item 3f). The userspace `SwapAbi` has six more variants than the book lists, and `RetrievePage` / `HardOom` have moved into kernel-internal scope.

### What's wrong

Current book at [`ch10-00-swap-overview.md` L217-L227](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch10-00-swap-overview.md#L217-L227):

```rust
pub enum SwapAbi {
    Invalid = 0,
    ClearMemoryNow = 1,
    GetFreePages = 2,
    RetrievePage = 3,
    HardOom = 4,
    StealPage = 5,
    ReleaseMemory = 6,
}
```

Actual userspace enum at [`services/xous-swapper/src/lib.rs` L14-L29](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/xous-swapper/src/lib.rs#L14-L29):

```rust
pub enum SwapAbi {
    Invalid = 0,
    ClearMemoryNow = 1,
    GetFreePages = 2,
    // RetrievePage = 3, // meant to be initiated within the kernel to itself
    // HardOom = 4, // meant to be initiated within the kernel to itself
    StealPage = 5,
    ReleaseMemory = 6,
    WritePage = 7,
    BlockErase = 8,
    DebugProcesses = 9,
    DebugServers = 10,
    DebugFree = 11,
    DebugInterrupts = 12,
}
```

`RetrievePage` and `HardOom` still live in the *kernel's* own `SwapAbi` enum ([`kernel/src/swap.rs` L35-L47](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/swap.rs#L35-L47)), so the book's description of what they do is still useful — they just move from "user-callable" to "kernel-internal."

The new variants are dispatched from [`kernel/src/syscall.rs`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/syscall.rs):

- `WritePage` — [L1157-L1170](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/syscall.rs#L1157-L1170)
(swapper-only; writes a page back to flash; args = `src_pid`, `flash_offset`, `page_vaddr_in_swapper`)
- `BlockErase` — [L1171-L1182](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/syscall.rs#L1171-L1182)
(swapper-only; erases a flash block; args = `src_pid`, `flash_offset`, `len`)
- `DebugServers` — [L1183-L1202](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/syscall.rs#L1183-L1202)
(prints the server table)

Userspace caller examples in [`services/xous-swapper/src/main.rs`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/xous-swapper/src/main.rs): [L809-L815](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/xous-swapper/src/main.rs#L809-L815) (`WritePage`), [L824-L830](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/xous-swapper/src/main.rs#L824-L830) (`BlockErase`), [L836-L838](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/xous-swapper/src/main.rs#L836-L838) (`DebugServers`).

### Fix

Updated the listing to match userspace, kept the existing prose for `ClearMemoryNow` / `GetFreePages` / `StealPage` / `ReleaseMemory`, prepended a "kernel-internal" framing paragraph for `RetrievePage` and `HardOom` (their per-variant prose is preserved as before, just behind the framing sentence), and added one paragraph each for the new variants. The chapter's one-paragraph-per-variant rhythm is preserved.

### Kernel/userspace divergence I noticed but did not fix

This is **a code bug, not a book bug** — flagging here so it doesn't get lost, with a sibling tracking issue filed at [betrusted-io/xous-core#884](https://github.com/betrusted-io/xous-core/issues/884). The book listing in this PR is unaffected (it documents the userspace surface, which is what `SwapOp` callers actually see), but the kernel/userspace numeric mismatch behind that surface has a latent crash hiding in it.

Kernel `SwapAbi` ([`kernel/src/swap.rs` L35-L47](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/swap.rs#L35-L47)) and userspace `SwapAbi` ([`services/xous-swapper/src/lib.rs` L14-L29](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/xous-swapper/src/lib.rs#L14-L29)) disagree on the numeric discriminants for the `Debug*` variants:

| Variant | userspace value | kernel value |
|---|---|---|
| `DebugProcesses` | 9 | — (undefined) |
| `DebugServers` | **10** | **9** |
| `DebugFree` | 11 | — (undefined) |
| `DebugInterrupts` | 12 | — (undefined) |

Live consequence on the wire: [`services/xous-swapper/src/main.rs` L836-L838](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/xous-swapper/src/main.rs#L836-L838) issues `xous::rsyscall(SwapOp(SwapAbi::DebugServers as usize, 0, 0, 0, 0, 0, 0)).unwrap()` — that's value `10` crossing the syscall boundary. Kernel `SwapAbi::from(10)` returns `Invalid` ([`kernel/src/swap.rs` L62](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/swap.rs#L62)), which lands on the `Invalid` arm at [`kernel/src/syscall.rs` L1203-L1209](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/syscall.rs#L1203-L1209): prints `"Invalid SwapOp: ..."` and returns `Err(UnhandledSyscall)`. The unconditional `.unwrap()` in the swapper then panics PID 2.

This is currently **latent** — `grep -rn "Opcode::DebugServers"` finds only the receiver in `xous-swapper/src/main.rs:836` itself; no other in-tree caller sends that IPC. So the broken path isn't reached at runtime today. But the moment a debug shell, test harness, or operator tool wires that IPC in, the swapper crashes.

The three "missing" kernel variants (`DebugProcesses`, `DebugFree`, `DebugInterrupts`) appear to be userspace-side dead code: no `SwapOp` caller in the tree references them, and the kernel already serves those debug names through a completely separate syscall — `SysCall::PlatformSpecific` → `PlatformCallAbi` at [`kernel/src/syscall.rs` L1230-L1345](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/kernel/src/syscall.rs#L1230-L1345), gated behind `#[cfg(feature = "debug-proc")]`. So the three extra userspace `SwapAbi::Debug*` variants look like vestiges of an in-progress or aborted refactor that never reached the kernel side.

The book listing in this PR is the userspace surface, since that's what `SwapOp` callers see, and the chapter's own caveat at [`ch10-00-swap-overview.md` L215](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch10-00-swap-overview.md#L215) ("`SwapAbi` may change rapidly, so please refer to the code for the latest details") is doing useful load-bearing work.

### Verification (local)

One-file change, +15/-5.

| Check | Result |
|---|---|
| `mdbook build` | clean, no warnings (same as `main`) |
| `mdbook test` | clean (same as `main`) |
| `bash ci/spellcheck.sh list` | six new uniquely-flagged words: `BlockErase`, `DebugFree`, `DebugInterrupts`, `DebugProcesses`, `DebugServers`, `WritePage` — all are code identifiers from the new enum variants being documented. No new English-language typos introduced. (Pre-existing flagged identifiers like `RetrievePage`, `ClearMemoryNow`, `HardOom`, etc. are also still flagged; the project's existing posture is to live with aspell flagging code identifiers in backticks.) |
| `bash ci/validate.sh` | same 3 pre-existing `link2print` panics as `main`, no new ones |

