### PR TITLE
ch03-01: correct and complete the virtual memory regions table

### DIFF
--- a/src/ch03-01-memory-layout.md
+++ b/src/ch03-01-memory-layout.md
@@ -71,20 +71,23 @@ There are different memory regions in virtual address space:
 | 0x6000_0000 | default | DEFAULT_BASE | Default region when calling `MapMemory(..., None, ..., ...) -- most threads have their stack here
 | 0x7fff_ffff | stack   | - | The default stack for the first thread - grows downwards from 0x8000_0000 not inclusive
 | 0xa000_0000 | swhal   | SWAP_HAL_VADDR | Hardware-specific pages for the swapper. For configs that use memory-mapped swap, contains the memory mapping (and thus constrains total swap size). For configs that use register-mapped swap, contains the HAL structures for the register driver. These configurations could potentially have effectively unlimited swap.
+| 0xb000_0000 | mmap    | MMAP_VIRT_BASE | Base of the virtual region used for `mmap`-style mappings. Shares the 0xA000_0000 - 0xE000_0000 aperture with the swap HAL region.
 | 0xe000_0000 | swpt    | SWAP_PT_VADDR | Swap page table roots. One page per process, contains virtual addresses (meant to be walked with code)
 | 0xe100_0000 | swcfg   | SWAP_CFG_VADDR | Swap configuration page. Contains all the arguments necessary to set up the swapper.
 | 0xe100_1000 | swrpt   | SWAP_RPT_VADDR | Location where the memory allocation tracker (runtime page tracker) is mapped when it is shared into userspace.
 | 0xe110_0000 | swcount | SWAP_COUNT_VADDR | Location of the block swap count table. This is statically allocated by the loader before the kernel starts.
-| 0xe800_0000 | swstack | SWAP_STACK_VADDR | Location of the swap handler context's stack pointer. Needed because swap events in TID=0 don't always have a proper stack. Builds down from this address.
+| 0xe180_0000 | swuart  | SWAP_APP_UART_VADDR | Virtual address of the userspace UART used by the swapper for early/debug output.
+| 0xe180_1000 | swuiram | SWAP_APP_UART_IFRAM_VADDR | Virtual address of the IFRAM region backing the swapper's debug UART.
+| 0xe800_0000 | swstack | SWAP_STACK_TOP_VADDR | Top of the swap handler context's stack. Needed because swap events in TID=0 don't always have a proper stack. Builds down from this address.
 | 0xff00_0000 | kernel  | USER_AREA_END | The end of user area and the start of kernel area
 | 0xff40_0000 | pgtable | PAGE_TABLE_OFFSET | A process' page table is located at this offset, accessible only to the kernel
 | 0xff80_0000 | pgroot  | PAGE_TABLE_ROOT_OFFSET | The root page table is located at this offset, accessible only to the kernel
-| 0xff80_1000 | process | PROCESS | The process context descriptor page
+| 0xff80_1000 | tcx     | THREAD_CONTEXT_AREA | The thread context descriptor page (formerly called `PROCESS`)
 | 0xff90_0000 | buffer  | USERSPACE_BUFFER | Location for userspace buffer mappings
 | 0xffc0_0000 | kargs   | KERNEL_ARGUMENT_OFFSET | Location of kernel arguments
 | 0xffd0_0000 | ktext   | - | Kernel `.text` area. Mapped into all processes.
 | 0xfff7_ffff | kstack  | - | Kernel stack top, grows down from 0xFFF8_0000 not inclusive
-| 0xfffe_ffff | exstack | - | Stack area for exception handlers, grows down from 0xFFFF_0000 not inclusive
+| 0xfffe_ffff | exstack | - | Stack area for exception handlers, grows down from `EXCEPTION_STACK_TOP` (0xFFFF_0000) not inclusive
 
 
 In addition, there are special addresses that indicate the end of a function. The kernel will set these as the return address for various situations, and they are documented here for completeness:


### PR DESCRIPTION
Refs #11 (Bucket 3, item 3g). Two existing rows have outdated `Variable` names; four constants exist in `xous-rs/src/arch/riscv/mem.rs` that the book doesn't mention at all.

### What's wrong

[`ch03-01-memory-layout.md` L66-L88](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch03-01-memory-layout.md#L66-L88) is the "Virtual Memory Regions" table.

Verified against [`xous-rs/src/arch/riscv/mem.rs`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/riscv/mem.rs):

| Book says | Code says | Where in mem.rs |
|---|---|---|
| `0xff80_1000 process PROCESS` | `THREAD_CONTEXT_AREA = 0xff80_1000` | [L19](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/riscv/mem.rs#L19) |
| `0xe800_0000 swstack SWAP_STACK_VADDR` | `SWAP_STACK_TOP_VADDR = 0xE800_0000` | [L41](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/riscv/mem.rs#L41) |
| missing | `MMAP_VIRT_BASE = 0xb000_0000` | [L12](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/riscv/mem.rs#L12) |
| missing | `SWAP_APP_UART_VADDR = 0xE180_0000` | [L39](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/riscv/mem.rs#L39) |
| missing | `SWAP_APP_UART_IFRAM_VADDR = 0xE180_1000` | [L40](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/riscv/mem.rs#L40) |
| `0xfffe_ffff exstack -` | `EXCEPTION_STACK_TOP = 0xffff_0000` | [L15](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/arch/riscv/mem.rs#L15) |

### Fix

Two renames and three insertions plus one variable-column fill. New rows are placed in address order.

```diff
 | 0xa000_0000 | swhal   | SWAP_HAL_VADDR | Hardware-specific pages for the swapper. …
+| 0xb000_0000 | mmap    | MMAP_VIRT_BASE | Base of the virtual region used for `mmap`-style mappings. Shares the 0xA000_0000 - 0xE000_0000 aperture with the swap HAL region.
 | 0xe000_0000 | swpt    | SWAP_PT_VADDR | …
 | 0xe100_0000 | swcfg   | SWAP_CFG_VADDR | …
 | 0xe100_1000 | swrpt   | SWAP_RPT_VADDR | …
 | 0xe110_0000 | swcount | SWAP_COUNT_VADDR | …
+| 0xe180_0000 | swuart  | SWAP_APP_UART_VADDR | Virtual address of the userspace UART used by the swapper for early/debug output.
+| 0xe180_1000 | swuiram | SWAP_APP_UART_IFRAM_VADDR | Virtual address of the IFRAM region backing the swapper's debug UART.
-| 0xe800_0000 | swstack | SWAP_STACK_VADDR | Location of the swap handler context's stack pointer. …
+| 0xe800_0000 | swstack | SWAP_STACK_TOP_VADDR | Top of the swap handler context's stack. …
 | 0xff00_0000 | kernel  | USER_AREA_END | …
 | 0xff40_0000 | pgtable | PAGE_TABLE_OFFSET | …
 | 0xff80_0000 | pgroot  | PAGE_TABLE_ROOT_OFFSET | …
-| 0xff80_1000 | process | PROCESS | The process context descriptor page
+| 0xff80_1000 | tcx     | THREAD_CONTEXT_AREA | The thread context descriptor page (formerly called `PROCESS`)
 | 0xff90_0000 | buffer  | USERSPACE_BUFFER | …
 …
-| 0xfffe_ffff | exstack | - | Stack area for exception handlers, grows down from 0xFFFF_0000 not inclusive
+| 0xfffe_ffff | exstack | - | Stack area for exception handlers, grows down from `EXCEPTION_STACK_TOP` (0xFFFF_0000) not inclusive
```

A few small judgment calls in the patch worth flagging:

- I kept the address column for the renamed `THREAD_CONTEXT_AREA` row at
the in-stack-top convention of the rest of the table and added "(formerly called `PROCESS`)" to the description for searchability.
- For `EXCEPTION_STACK_TOP`, the const value (`0xFFFF_0000`) is one byte
*above* the existing exstack row's address (`0xfffe_ffff`, the in-stack top), so it doesn't naturally fit any existing "Variable" cell. The kstack row above it has the same shape (no constant for its in-stack top, "-" in Variable). I kept the variable column at `-` to match that convention and named `EXCEPTION_STACK_TOP` in the description instead. If you'd rather have a dedicated row at `0xffff_0000` with `EXCEPTION_STACK_TOP` in the Variable column, happy to swap that in.
- Short name codes for the new rows (`mmap`, `swuart`, `swuiram`) follow
the existing `sw*` convention.

### Verification (local)

One-file change, +6/-3.

| Check | Result |
|---|---|
| `mdbook build` | clean, no warnings (same as `main`) |
| `mdbook test` | clean (same as `main`) |
| `bash ci/spellcheck.sh list` | eight new uniquely-flagged words: `IFRAM`, `mmap`, `MMAP`, `swapper's`, `swuart`, `swuiram`, `UART`, `VIRT` — all code/identifier text in the new rows. No new English-language typos. |
| `bash ci/validate.sh` | same 3 pre-existing `link2print` panics as `main`, no new ones |
