### PR TITLE
ch07-02: list ReplyAndReceiveNext and TryReceiveMessage as caller idioms

### DIFF
--- a/src/ch07-02-caller-idioms.md
+++ b/src/ch07-02-caller-idioms.md
@@ -141,3 +141,8 @@ With the above template in mind, click on the following for examples of each of 
 - [Asynchronous](ch07-05-asynchronous.md) or "push notifications"
 - [Deferred response](ch07-06-deferred.md)
 - [Forwarding messages](ch07-07-forwarding.md)
+
+Two further server patterns exist as raw syscalls without dedicated example chapters:
+
+- [`ReplyAndReceiveNext`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/syscall.rs#L457-L492) replies to the just-handled message and blocks waiting for the next one in a single syscall. This is the high-throughput server inner loop; see the discussion of `scalar5` messaging in [Messaging Performance](ch07-08-performance.md) for the performance-oriented usage.
+- [`TryReceiveMessage`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/syscall.rs#L161-L175) is the non-blocking variant of `ReceiveMessage`, returning `Result::None` immediately when the queue is empty. Useful for poll-style servers that need to interleave message handling with other work.


### PR DESCRIPTION
Refs #11 (Bucket 3, item 3h). The audit listed roughly a dozen undocumented syscalls; most of them are kernel-internal or diagnostic plumbing, but two are bona fide server-side patterns that belong in the caller-idioms list.

### Scope (kept narrow on purpose)

Two changes to [`ch07-02-caller-idioms.md` L139-L143](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch07-02-caller-idioms.md#L139-L143):

1. Add `ReplyAndReceiveNext` to the caller-idioms list.
[`xous-rs/src/syscall.rs` L457-L492](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/syscall.rs#L457-L492) is the syscall:
   > Return a message with the given Message ID and the provided
   > parameters, and listen for another message on the server ID that
   > sent this message. This call is meant to be used in the main loop
   > of a server in order to reduce latency when that server is called
   > frequently.
It is referenced once in passing at [`ch07-08-performance.md` L12](https://github.com/betrusted-io/xous-book/blob/51ed20d9326d2b6dc0081c8b0b2e50a9972cecfa/src/ch07-08-performance.md#L12) (the `scalar5` message type lives inside it) but not enumerated as a server pattern. Real-world callers: [`services/graphics-server/src/main.rs` L218](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/graphics-server/src/main.rs#L218), [`services/usb-bao1x/src/main.rs` L284](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/services/usb-bao1x/src/main.rs#L284).

2. Add `TryReceiveMessage` to the same list.
[`xous-rs/src/syscall.rs` L161-L175](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/syscall.rs#L161-L175) is the syscall — non-blocking variant of `ReceiveMessage`. Zero mentions in the book under either CamelCase or snake_case.

### What's deliberately out of scope

The Bucket 3h audit also names: `ConnectForProcess`, `ReturnScalar5`, `JoinThread`, `WaitEvent`, `ReadyThreads`, `ReturnToParent`, `UpdateMemoryFlags`, `SetMemRegion`, `AdjustProcessLimit`, `VirtToPhys`, `VirtToPhysPid`, `RawTrng`, `PlatformSpecific`. Most of these are either:

- kernel-internal (`ConnectForProcess`, `ReturnToParent`,
`AdjustProcessLimit`),
- diagnostics (`PlatformSpecific`'s `Debug*` variants, `RawTrng`),
- low-level memory plumbing better-suited to rustdoc than to the book
(`UpdateMemoryFlags`, `SetMemRegion`, `VirtToPhys*`),

so my read is they want a separate, more-focused effort — probably a new chapter under ch07 ("Other Syscalls" / "Diagnostic Syscalls") or, more likely, rustdoc coverage of `xous_kernel::SysCall` itself.

I can do either of those as a follow-up if you want — let me know which.

### Fix

```diff
 - [Non-synchronizing](ch07-03-nonsynchronizing.md)
 - [Synchronous](ch07-04-synchronizing.md). Includes an example of how to use raw messages (instead of `rkyv`) for serializing data.
 - [Asynchronous](ch07-05-asynchronous.md) or "push notifications"
 - [Deferred response](ch07-06-deferred.md)
 - [Forwarding messages](ch07-07-forwarding.md)
+
+Two further server patterns exist as raw syscalls without dedicated example chapters:
+
+- [`ReplyAndReceiveNext`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/syscall.rs#L457-L492) replies to the just-handled message and blocks waiting for the next one in a single syscall. This is the high-throughput server inner loop; see the discussion of `scalar5` messaging in [Messaging Performance](ch07-08-performance.md) for the performance-oriented usage.
+- [`TryReceiveMessage`](https://github.com/betrusted-io/xous-core/blob/5397e1b488c081566cef2c0e597e05426f67c1c3/xous-rs/src/syscall.rs#L161-L175) is the non-blocking variant of `ReceiveMessage`, returning `Result::None` immediately when the queue is empty. Useful for poll-style servers that need to interleave message handling with other work.
```

The "four patterns" wording above L137 still holds for the original idioms with dedicated example pages; the two new entries are bracketed off with their own "further patterns" sentence so the reader knows they don't have walkthroughs yet.

### Verification (local)

One-file change, +5/+0.

| Check | Result |
|---|---|
| `mdbook build` | clean, no warnings (same as `main`) |
| `mdbook test` | clean (same as `main`) |
| `bash ci/spellcheck.sh list` | three new uniquely-flagged words on `ch07-02`: `ReceiveMessage`, `syscall`, `syscalls`. All three are common in the rest of the book (e.g. `syscall(s)` appears throughout ch03 and ch07-08) — they're not in this specific chapter's pre-existing flagged set, but aren't new project-wide misspellings. |
| `bash ci/validate.sh` | same 3 pre-existing `link2print` panics as `main`, no new ones |
